### PR TITLE
Update workflows and env variables to use LBUG instead of KUZU

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,17 +16,16 @@ jobs:
       - name: Prebuild - get version
         shell: bash
         run: |
-          VERSION=$(node -e 'fs=require("fs");console.log(JSON.parse(fs.readFileSync("package.json")).dependencies.kuzu)')
+          VERSION=$(node -e 'fs=require("fs");console.log(JSON.parse(fs.readFileSync("package.json")).dependencies.lbug)')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Set tags
+        run: echo "TAGS=ghcr.io/${{ env.OWNER }}/api-server:latest,ghcr.io/${{ env.OWNER }}/api-server:${{ env.VERSION }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -39,7 +38,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: kuzudb/api-server:latest, kuzudb/api-server:${{ env.VERSION }}, ghcr.io/${{ github.repository_owner }}/api-server:latest, ghcr.io/${{ github.repository_owner }}/api-server:${{ env.VERSION }}
+          tags: ${{ env.TAGS }}
           build-args: |
             SKIP_GRAMMAR=true
             SKIP_BUILD_APP=true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "explorer"]
 	path = explorer
-	url = https://github.com/kuzudb/explorer
+	url = https://github.com/LadybugDB/explorer

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ USER node
 # Set working directory
 WORKDIR /home/node/app
 
-# Install dependencies and reduce size of kuzu node module
+# Install dependencies and reduce size of lbug node module
 RUN npm install &&\
-    rm -rf node_modules/kuzu/prebuilt node_modules/kuzu/kuzu-source
+    rm -rf node_modules/lbug/prebuilt node_modules/lbug/lbug-source
 
 # Expose port
 EXPOSE 8000
@@ -38,7 +38,7 @@ EXPOSE 8000
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=8000
-ENV KUZU_DIR=/database
+ENV LBUG_DIR=/database
 ENV CROSS_ORIGIN=true
 
 # Run app

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Kùzu Inc.
+Copyright (c) 2024-2025 Ladybug Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Kùzu API Server
+# Ladybug API Server
 
-REST-style API server for the Kùzu graph database powered by Express.js.
+REST-style API server for the Ladybug graph database powered by Express.js.
 
 ## Get started
 
-Kùzu API Server is launched as a Docker container. Please refer to the [Docker documentation](https://docs.docker.com/get-docker/) for details on how to install and use Docker.
+Ladybug API Server is launched as a Docker container. Please refer to the [Docker documentation](https://docs.docker.com/get-docker/) for details on how to install and use Docker.
 
-To access an existing Kùzu database, you can mount its path to the `/database` directory as follows:
+To access an existing Ladybug database, you can mount its path to the `/database` directory as follows:
 
 ```bash
 docker run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database \
-           -e KUZU_FILE={database file name} \
-           --rm kuzudb/api-server:latest
+           -e LBUG_FILE={database file name} \
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
-By mounting local database files to Docker via `-v {path to the directory containing the database file}:/database` and `-e KUZU_FILE={database file name}`,
-the changes done through the API server will persist to the local database files after the server is shutdown. If the directory is mounted but the `KUZU_FILE` environment variable is not set, the API server will look for a file named `database.kz` in the mounted directory or create a new database file named `database.kz` in the mounted directory if it does not exist.
+By mounting local database files to Docker via `-v {path to the directory containing the database file}:/database` and `-e LBUG_FILE={database file name}`,
+the changes done through the API server will persist to the local database files after the server is shutdown. If the directory is mounted but the `LBUG_FILE` environment variable is not set, the API server will look for a file named `database.kz` in the mounted directory or create a new database file named `database.kz` in the mounted directory if it does not exist.
 
 The `--rm` flag tells docker that the container should automatically be removed after we close docker.
 
@@ -25,7 +25,7 @@ If the launching is successful, you should see the logs similar to the following
 ```
 [00:46:50.833] INFO (1): Access mode: READ_WRITE
 [00:46:50.834] INFO (1): CORS enabled for all origins
-[00:46:50.853] INFO (1): Version of Kùzu: 0.3.1
+[00:46:50.853] INFO (1): Version of Ladybug: 0.3.1
 [00:46:50.854] INFO (1): Deployed server started on port: 8000
 ```
 
@@ -38,9 +38,9 @@ By default, the API server is launched in read-write mode, which means that you 
 ```bash
 docker run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database \
-           -e KUZU_FILE={database file name} \
+           -e LBUG_FILE={database file name} \
            -e MODE=READ_ONLY \
-           --rm kuzudb/api-server:latest
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
 The API server will then be launched in read-only mode, and you will see the following log message:
@@ -53,16 +53,16 @@ In read-only mode, you can still issue read queries, but you cannot run write qu
 
 #### Buffer pool size
 
-By default, the API server is launched with a maximum buffer pool size of 80% of the available memory. If you want to launch API server with a different buffer pool size, you can do so by setting the `KUZU_BUFFER_POOL_SIZE` environment variable to the desired value in bytes as follows.
+By default, the API server is launched with a maximum buffer pool size of 80% of the available memory. If you want to launch API server with a different buffer pool size, you can do so by setting the `LBUG_BUFFER_POOL_SIZE` environment variable to the desired value in bytes as follows.
 
 For example, to launch the API server with a buffer pool size of 1GB, you can run the following command.
 
 ```bash
 docker run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database \
-           -e KUZU_FILE={database file name} \
-           -e KUZU_BUFFER_POOL_SIZE=1073741824 \
-           --rm kuzudb/api-server:latest
+           -e LBUG_FILE={database file name} \
+           -e LBUG_BUFFER_POOL_SIZE=1073741824 \
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
 #### Cross-Origin Resource Sharing (CORS)
@@ -72,9 +72,9 @@ By default, the API server is launched with CORS enabled for all origins. If you
 ```bash
 docker run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database \
-           -e KUZU_FILE={database file name} \
+           -e LBUG_FILE={database file name} \
            -e CROSS_ORIGIN=false \
-           --rm kuzudb/api-server:latest
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
 ### Launch with Podman
@@ -86,8 +86,8 @@ For example:
 ```bash
 podman run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database:U \
-           -e KUZU_FILE={database file name} \
-           --rm kuzudb/api-server:latest
+           -e LBUG_FILE={database file name} \
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
 or,
@@ -95,16 +95,16 @@ or,
 ```bash
 podman run -p 8000:8000 \
            -v {path to the directory containing the database file}:/database \
-           -e KUZU_FILE={database file name} \
+           -e LBUG_FILE={database file name} \
            --userns=keep-id \
-           --rm kuzudb/api-server:latest
+           --rm ghcr.io/ladybugdb/api-server:latest
 ```
 
 Please refer to the official Podman docs for [mounting external volumes](https://docs.podman.io/en/latest/markdown/podman-run.1.html#mounting-external-volumes) and [user namespace mode](https://https://docs.podman.io/en/latest/markdown/podman-run.1.html#userns-mode) for more information.
 
 ## API endpoints
 
-The Kùzu API server provides the following endpoints:
+The Ladybug API server provides the following endpoints:
 
 ### `GET /`:
 
@@ -326,4 +326,4 @@ for both `amd64` and `arm64` platforms.
 
 ## Contributing
 
-We welcome contributions to Kùzu API Server. By contributing to Kùzu API Server, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+We welcome contributions to Ladybug API Server. By contributing to Ladybug API Server, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/index.js
+++ b/index.js
@@ -49,12 +49,12 @@ database
   .then((res) => {
     const version = res.version;
     const storageVersion = res.storageVersion;
-    logger.info("Version of Kùzu: " + version);
-    logger.info("Storage version of Kùzu: " + storageVersion);
+    logger.info("Version of Ladybug: " + version);
+    logger.info("Storage version of Ladybug: " + storageVersion);
     app.listen(PORT, () => {
       logger.info("Deployed server started on port: " + PORT);
     });
   })
   .catch((err) => {
-    logger.error("Error getting version of Kùzu: " + err);
+    logger.error("Error getting version of Ladybug: " + err);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "kuzu-api-server",
+  "name": "lbug-api-server",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kuzu-api-server",
+      "name": "lbug-api-server",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "kuzu": "0.11.3",
+        "lbug": "0.14.1",
         "pino": "^8.16.1",
         "pino-pretty": "^10.2.3"
       }
@@ -989,10 +989,10 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/kuzu": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/kuzu/-/kuzu-0.11.2.tgz",
-      "integrity": "sha512-4DrhdfjxImGqtfuQBhPuptQBQ6OT8G/n/cdpj7etgNJ7XeT6SeMGdo4duMvsSATRommzhTxeLwm7FHUIiYTjhg==",
+    "node_modules/lbug": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/lbug/-/lbug-0.14.1.tgz",
+      "integrity": "sha512-3NgxN0RL9lRFmuROLk1Z4fxDaYS0REE6rvcgNX7pCZlde53yTb3RzRP3KXG+GG5J6bFi1UKnXkuF/xAJOSLOlw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kuzu-api-server",
+  "name": "lbug-api-server",
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "kuzu": "0.11.2",
+    "lbug": "0.14.1",
     "pino": "^8.16.1",
     "pino-pretty": "^10.2.3"
   }


### PR DESCRIPTION
Closes #1.

## Description

- Rebrand Kuzu → Ladybug across docs, logs, and licensing; rename env vars `KUZU_*` → `LBUG_*`.
- Update lowercase `kuzu` identifiers to `lbug` (package names, module paths, Docker image refs).
- Bump `lbug` npm dependency to 0.14.1 (latest version).
- Align CI Docker publish workflow to GHCR-only tags (`ghcr.io/<owner>/api-server:*`) and read version from `lbug`.

## Notes
There are breaking changes: env vars renamed, so the workflow deployments have been updated accordingly.

## Results

Grepping for "kuzu" in all forms (upper and lowercase) doesn't yield any results, so I think I got them all.